### PR TITLE
Fixed issue where Admins/Trainers profiles would break when editing t…

### DIFF
--- a/src/app/components/accountinfo/accountinfo.component.html
+++ b/src/app/components/accountinfo/accountinfo.component.html
@@ -204,27 +204,15 @@
                   <button aria-hidden="true" class="btn" (click)="removeContact(item)">-</button>
                 </div>
               </div>
-              <!--Moving Driver/Rider toggle to page 2, so it isn't the only thing on page-->
-              <div class="input-group mb-3">
-                <div class="btn-group" role="group" aria-label="btn groups">
-                  <button type="button" class="btn" id="riderBtn" (click)="isRider()">Rider</button>
-                  <button type="button" class="btn" id="driverBtn" (click)="isDriver()">Driver</button>
-                </div>
-              </div>
               <div>
                 <span style="padding-right: 20px"><button class="btn btnNextPrevious" (click)="bioPrevious()">Previous</button></span>
                 <span> <button class="btn btnNextPrevious" (click)="bioNext()">Next</button></span>
-              </div>
-              <div style="padding-top: 20px">
-                <div *ngIf="!requiredCarFields" class="alert alert-danger">
-                  Please select Driver or Rider
-                </div>
               </div>
             </div>
           </ng-template>
         </ngb-tab>
       </div>
-     <!--  <div label="CAR INFO div">
+      <div label="CAR INFO div">
         <ngb-tab title="3" id="3">
           <ng-template ngbTabContent>
             <div class="input-group mb-3">
@@ -244,10 +232,10 @@
               </div>
             </div>
           </ng-template>
-        </ngb-tab> 
-      </div> -->
+        </ngb-tab>
+      </div>
       <div label="CONFIRMATION div">
-        <ngb-tab title="3" id="3">
+        <ngb-tab title="4" id="4">
           <ng-template ngbTabContent>
             <div class="container-fluid">
               <br>

--- a/src/app/components/view-profile/view-profile.component.ts
+++ b/src/app/components/view-profile/view-profile.component.ts
@@ -82,7 +82,11 @@ export class ViewProfileComponent implements OnInit {
     document.getElementById("batchEnd").removeAttribute("disabled");
     document.getElementById("dayStart").removeAttribute("disabled");
     document.getElementById("switchRoles").removeAttribute("hidden");
-    document.getElementById("switchStates").removeAttribute("hidden");
+    //Had to put this in an if; Page would break if Admin or Trainer clicked edit
+    //Since for them, this button didn't exist to make visible
+    if(this.currentRole === "DRIVER" || this.currentRole === "RIDER"){
+      document.getElementById("switchStates").removeAttribute("hidden");
+    }
     document.getElementById("edit").style.display = "none";
     document.getElementById("submit").style.display = "inline";
     document.getElementById("batchEnd").setAttribute("type", "date");


### PR DESCRIPTION
Found bug where Admin/Trainer's profiles would break when clicking edit profile.  
An error would occur in edit() function where a button that does not exist for an admin would be set to visible.  Since there is no button to make visible the rest of the functionality for profile editing would break.

Fixed by adding an if condition to check if a user is a rider or driver before attempting to said the inactivity state toggle to visible.