### PR TITLE
Switched download component to use principal instead of session store

### DIFF
--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -28,7 +28,7 @@
 <div *ngIf="session" style="margin-left: 10px;">
   <img src="../../assets/img/large_profile_default.png" *ngIf="!imageFile;else profileimage" width="50px" height="50px">
   <ng-template #profileimage>
-    <img [src]="DomSanitizationService.bypassSecurityTrustUrl(imageFile)">
+    <img [src]="DomSanitizationService.bypassSecurityTrustUrl(imageFile)" width="50px" height="50px">
   </ng-template>
 </div>
 

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -82,7 +82,7 @@ export class NavbarComponent implements OnInit {
   }
 
 downloadFile() {
-    this.downloadService.downloadFile(sessionStorage.getItem('id')).subscribe(resp => {
+    this.downloadService.downloadFile(this.principal.id.toString()).subscribe(resp => {
       this.createImageFromBlob(resp);
     }, error => {
       console.log(error);

--- a/src/app/components/view-profile/view-profile.component.ts
+++ b/src/app/components/view-profile/view-profile.component.ts
@@ -133,11 +133,9 @@ export class ViewProfileComponent implements OnInit {
   switchRole() {
     if (this.principal.role === Role.Driver) {
       this.principal.role = Role.Rider;
-      this.authService.changePrincipal(this.principal);
       this.getRole();
     } else if (this.principal.role === Role.Rider) {
       this.principal.role = Role.Driver;
-      this.authService.changePrincipal(this.principal);
       this.getRole();
     } else {
       console.log('nope');

--- a/src/app/image-upload/image-upload.component.html
+++ b/src/app/image-upload/image-upload.component.html
@@ -2,7 +2,7 @@
     <span>Select Image</span>
     <input accept="image/*" type="file" name="file" (change)="onFileSelect($event)">
     <button (click)="onFileUpload()">Upload</button>
-    <div class="progress">
+    <div class="progress" id="UploadStats">
     <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" [style.width]="imageUploadProgress"></div>
     </div>
 </label>

--- a/src/app/image-upload/image-upload.component.ts
+++ b/src/app/image-upload/image-upload.component.ts
@@ -47,6 +47,9 @@ export class ImageUploadComponent {
           if (event.type === HttpEventType.UploadProgress) {
             this.imageUploadProgress = Math.round(event.loaded / event.total) * 100 + '%';
             console.log('Upload Progress: ', this.imageUploadProgress);
+            if(this.imageUploadProgress == '100%'){
+              document.getElementById("UploadStats").innerHTML = "Upload Complete!";
+            }
           }
         },
         err => {


### PR DESCRIPTION
Fixed issue where clicking profile toggles for rider/driver and active/inactive set properties before submitting changes.  Profile picture display also now uses principal instead of session storage, so profile pictures can be displayed when the user has one.  Additionally, the user will receive feedback when their profile picture finishes uploading.